### PR TITLE
Update tide version to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }
-tide = "0.12.0"
+tide = "0.13.0"
 async-tls = "0.9.0"
 rustls = "0.18.0"
 async-h1 = "2.1.0"


### PR DESCRIPTION
Currently, `tide-rustls:0.1.1` cannot be used with tide:0.13.0.