### PR TITLE
Disable tide default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@ categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }
-tide = "0.13.0"
+tide = { version = "0.13.0", default-features = false, features = ["h1-server"] }
 async-tls = "0.9.0"
 rustls = "0.18.0"
 async-h1 = "2.1.0"
 async-dup = "1.2.1"
+
+[dev-dependencies]
+tide = { version = "0.13.0" }


### PR DESCRIPTION
This avoids pulling in the logger feature for tide, as mentioned https://github.com/http-rs/tide/issues/548