### PR TITLE
log info on listen

### DIFF
--- a/src/tls_listener.rs
+++ b/src/tls_listener.rs
@@ -142,8 +142,10 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State> for TlsListenerBuil
 #[tide::utils::async_trait]
 impl<State: Clone + Send + Sync + 'static> Listener<State> for TlsListener {
     async fn listen(&mut self, app: Server<State>) -> io::Result<()> {
+        let s = format!("{}", self);
         let acceptor = self.configure().await?;
         let listener = self.connect().await?;
+        tide::log::info!("Server listening on {}", s);
         let mut incoming = listener.incoming();
 
         while let Some(stream) = incoming.next().await {


### PR DESCRIPTION
I'd noticed and was slightly confused that the other listeners (in tide itself) log to info on listen, but the rustls one here did not.

It's slightly weirdly implemented because of ownership issues, I had to format the log before borrowing self as mutable