### PR TITLE
Add support for custom TLS acceptors

### DIFF
--- a/src/custom_tls_acceptor.rs
+++ b/src/custom_tls_acceptor.rs
@@ -1,0 +1,31 @@
+use async_rustls::server::TlsStream;
+use async_std::net::TcpStream;
+
+/// The CustomTlsAcceptor trait provides a custom implementation of accepting
+/// TLS connections from a [`TcpStream`]. tide-rustls will call the
+/// [`CustomTlsAcceptor::accept`] function for each new [`TcpStream`] it
+/// accepts, to obtain a [`TlsStream`]).
+///
+/// Implementing this trait gives you control over the TLS negotiation process,
+/// and allows you to process some TLS connections internally without passing
+/// them through to tide, such as for multiplexing or custom ALPN negotiation.
+#[tide::utils::async_trait]
+pub trait CustomTlsAcceptor: Send + Sync {
+    /// Accept a [`TlsStream`] from a [`TcpStream`].
+    ///
+    /// If TLS negotiation succeeds, but does not result in a stream that tide
+    /// should process HTTP connections from, return `Ok(None)`.
+    async fn accept(&self, stream: TcpStream) -> std::io::Result<Option<TlsStream<TcpStream>>>;
+}
+
+/// Crate-private adapter to make `async_rustls::TlsAcceptor` implement
+/// `CustomTlsAcceptor`, without creating a conflict between the two `accept`
+/// methods.
+pub(crate) struct StandardTlsAcceptor(pub(crate) async_rustls::TlsAcceptor);
+
+#[tide::utils::async_trait]
+impl CustomTlsAcceptor for StandardTlsAcceptor {
+    async fn accept(&self, stream: TcpStream) -> std::io::Result<Option<TlsStream<TcpStream>>> {
+        self.0.accept(stream).await.map(Some)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
     unused_qualifications
 )]
 
+mod custom_tls_acceptor;
 mod tcp_connection;
 mod tls_listener;
 mod tls_listener_builder;
@@ -38,6 +39,7 @@ pub(crate) use tcp_connection::TcpConnection;
 pub(crate) use tls_listener_config::TlsListenerConfig;
 pub(crate) use tls_stream_wrapper::TlsStreamWrapper;
 
+pub use custom_tls_acceptor::CustomTlsAcceptor;
 pub use tls_listener::TlsListener;
 pub use tls_listener_builder::TlsListenerBuilder;
 

--- a/src/tls_listener_config.rs
+++ b/src/tls_listener_config.rs
@@ -1,9 +1,11 @@
 use std::fmt::{self, Debug, Formatter};
 
-use async_rustls::TlsAcceptor;
 use rustls::ServerConfig;
 
+use super::CustomTlsAcceptor;
+
 use std::path::PathBuf;
+use std::sync::Arc;
 
 impl Default for TlsListenerConfig {
     fn default() -> Self {
@@ -12,7 +14,7 @@ impl Default for TlsListenerConfig {
 }
 pub(crate) enum TlsListenerConfig {
     Unconfigured,
-    Acceptor(TlsAcceptor),
+    Acceptor(Arc<dyn CustomTlsAcceptor>),
     ServerConfig(ServerConfig),
     Paths { cert: PathBuf, key: PathBuf },
 }


### PR DESCRIPTION
Allow the configuration to provide a custom object to accept a TlsStream
from a TcpStream.

This gives total control over the TLS negotiation process, such as to
process some TLS streams or ALPN negotiations internally without passing
them through to tide. In particular, this allows responding to ACME
tls-alpn-01 challenges.